### PR TITLE
Fix the URL encoding as specified in the OPML RadioTime API.

### DIFF
--- a/mopidy_tunein/translator.py
+++ b/mopidy_tunein/translator.py
@@ -8,6 +8,7 @@ from mopidy.models import Album, Artist, Ref, Track
 
 logger = logging.getLogger(__name__)
 
+TUNEIN_API_ENCODING = 'utf-8'
 
 TUNEIN_ID_PROGRAM = 'program'
 TUNEIN_ID_STATION = 'station'
@@ -98,4 +99,4 @@ def mopidy_to_tunein_query(mopidy_query):
         for value in values:
             if field == 'any':
                 tunein_query.append(value)
-    return urllib.pathname2url(' '.join(tunein_query))
+    return urllib.pathname2url(' '.join(tunein_query).encode(TUNEIN_API_ENCODING))


### PR DESCRIPTION
The following search query generates an error in urllib module that only accepts encoded strings
$ mopidy &
$ mpc search any 'é'
KeyError: u'\xe9'

This can be easily reproduced with
 $ python2 -m '__import__("urllib").pathname2url(u"é")'