### PR TITLE
Stop inheriting from StreamPlaybackProvider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Changelog
 v0.4.0 (2016-02-16)
 -------------------
 
-- Borrow Mopidy's internal stream unwrapping to avoid incompatibilities with Mopidy v2.0.0 (PR: #27)
+- Borrow Mopidy's internal stream unwrapping to avoid incompatibilities with Mopidy v2.0.0 (PR: #28)
 - Improved handling of malformed pls playlists.
 
 v0.3.0 (2016-02-06)

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,12 @@ Project resources
 Changelog
 =========
 
+v0.4.0 (2016-02-16)
+-------------------
+
+- Borrow Mopidy's internal stream unwrapping to avoid incompatibilities with Mopidy v2.0.0 (PR: #27)
+- Improved handling of malformed pls playlists.
+
 v0.3.0 (2016-02-06)
 -------------------
 

--- a/mopidy_tunein/__init__.py
+++ b/mopidy_tunein/__init__.py
@@ -4,7 +4,7 @@ import os
 
 from mopidy import config, ext
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 
 class Extension(ext.Extension):

--- a/mopidy_tunein/tunein.py
+++ b/mopidy_tunein/tunein.py
@@ -93,7 +93,7 @@ def parse_pls(data):
                     if cp.get(section, 'length%d' % (i+1)) == '-1':
                         yield cp.get(section, 'file%d' % (i+1))
                 else:
-                    yield cp.get(section, 'file%d' % (i+1))                
+                    yield cp.get(section, 'file%d' % (i+1))
             except configparser.NoOptionError:
                 return
 
@@ -308,11 +308,11 @@ class TuneIn(object):
             parser = find_playlist_parser(extension, content_type)
             if parser:
                 playlist_data = StringIO.StringIO(playlist)
-                try: 
+                try:
                     results = [u for u in parser(playlist_data)
                                if u and u != url]
                 except Exception as e:
-                    logger.error('TuneIn playlist parsing failed %s' % e) 
+                    logger.error('TuneIn playlist parsing failed %s' % e)
                 if not results:
                     logger.debug('Parsing failure, '
                                  'malformed playlist: %s' % playlist)


### PR DESCRIPTION
https://github.com/mopidy/mopidy/pull/1447 introduces changes to `StreamPlaybackProvider` which makes it incompatible with what we try and reuse it for. As a quick fix this PR 'borrows' the specific `_unwrap_stream` function we were utilising. In doing so we also now make use of Mopidy's internal API which is a bad idea; this API is subject to change without warning and we won't complain if/when this happens. We should therefore aim to revisit this at some point and fix is properly. 