### PR TITLE
Fix misuse of flags in re.sub() call

### DIFF
--- a/mopidy_tunein/tunein.py
+++ b/mopidy_tunein/tunein.py
@@ -99,7 +99,7 @@ def parse_pls(data):
 
 
 def fix_asf_uri(uri):
-    return re.sub(r'http://(.+\?mswmext=\.asf)', r'mms://\1', uri, re.I)
+    return re.sub(r'http://(.+\?mswmext=\.asf)', r'mms://\1', uri, flags=re.I)
 
 
 def parse_old_asx(data):


### PR DESCRIPTION
The 4th argument of `re.sub()` is maximum number of substitutions, not flags.

Found using [pydiatra](https://github.com/jwilk/pydiatra).