### PR TITLE
Use HTTPS for making requests to TuneIn servers

### DIFF
--- a/mopidy_tunein/tunein.py
+++ b/mopidy_tunein/tunein.py
@@ -191,7 +191,7 @@ class TuneIn:
     ID_UNKNOWN = "unknown"
 
     def __init__(self, timeout, filter_=None, session=None):
-        self._base_uri = "http://opml.radiotime.com/%s"
+        self._base_uri = "https://opml.radiotime.com/%s"
         self._session = session or requests.Session()
         self._timeout = timeout / 1000.0
         if filter_ in [TuneIn.ID_PROGRAM, TuneIn.ID_STATION]:


### PR DESCRIPTION
As far as I can tell, TuneIn's "API" is fully available on HTTPS. Given Apple
and Google are requiring all apps to not use HTTP, I think it's a pretty
safe bet that HTTPS is fully supported.