### PR TITLE
Turn off strict parsing for pls playlist files

### DIFF
--- a/mopidy_tunein/tunein.py
+++ b/mopidy_tunein/tunein.py
@@ -75,7 +75,7 @@ def parse_m3u(data):
 def parse_pls(data):
     # Copied from mopidy.audio.playlists
     try:
-        cp = configparser.RawConfigParser()
+        cp = configparser.RawConfigParser(strict=False)
         cp.read_string(data.decode())
     except configparser.Error:
         return


### PR DESCRIPTION
Some PLS files contain one 'Version' key for each file in the playlist. This ultimately has no impact on how mopidy parses files in the playlist, and therefore it should be as tolerant as possible of real-world playlist files.

This matches a similar change request submitted to the mopidy core:

https://github.com/mopidy/mopidy/pull/1923

This change is primarily designed to resolve an issue where playing back certain TuneIn radio streams. For example, the following stream does not work due to having multiple `Version` keys:

URI: tunein:station:s10113
TuneIn request URL: http://opml.radiotime.com/Tune.ashx?render=json&id=s10113
Playlist URL: http://www.abc.net.au/res/streaming/audio-live/shout-mp3/local-melbourne.pls

The above playlist file is successfully parsed after turning of strict parsing.